### PR TITLE
Fix file-based app HotReloadHost package surface

### DIFF
--- a/samples/NXUI.Sample.FileApp/App.cs
+++ b/samples/NXUI.Sample.FileApp/App.cs
@@ -1,0 +1,13 @@
+#!/usr/local/share/dotnet/dotnet run
+#:package NXUI.Desktop@12.0.0
+using Avalonia.Controls;
+using Avalonia.Styling;
+using NXUI.HotReload;
+using static NXUI.Builders;
+
+return HotReloadHost.Run(
+    () => Window().Content(Label().Content("NXUI")),
+    "NXUI",
+    args,
+    ThemeVariant.Dark,
+    ShutdownMode.OnLastWindowClose);

--- a/src/NXUI.Desktop/NXUI.Desktop.csproj
+++ b/src/NXUI.Desktop/NXUI.Desktop.csproj
@@ -19,7 +19,11 @@
     <PackageReference Include="Tmds.DBus.Protocol" Version="$(TmdsDbusProtocolVersion)" />
   </ItemGroup>
   <ItemGroup>
-    <Content Include="*.props">
+    <Content Include="NXUI.props">
+      <Pack>true</Pack>
+      <PackagePath>build\$(PackageId).props;buildTransitive\$(PackageId).props</PackagePath>
+    </Content>
+    <Content Include="ImplicitUsings.props">
       <Pack>true</Pack>
       <PackagePath>build\;buildTransitive\</PackagePath>
     </Content>

--- a/tests/NXUI.HotReload.Tests/HotReloadHostApiTests.cs
+++ b/tests/NXUI.HotReload.Tests/HotReloadHostApiTests.cs
@@ -1,0 +1,28 @@
+using System;
+using Avalonia.Controls;
+using Avalonia.Styling;
+using Xunit;
+
+namespace NXUI.HotReload.Tests;
+
+public sealed class HotReloadHostApiTests
+{
+    [Fact]
+    public void HotReloadHost_Is_Public_In_Expected_Namespace()
+    {
+        var type = typeof(HotReloadHost);
+
+        Assert.Equal("NXUI.HotReload.HotReloadHost", type.FullName);
+        Assert.True(type.IsPublic);
+        Assert.True(type.IsAbstract);
+        Assert.True(type.IsSealed);
+    }
+
+    [Fact]
+    public void Run_Exposes_File_Based_App_Signature()
+    {
+        Func<Func<object>, string, string[], ThemeVariant?, ShutdownMode, int> run = HotReloadHost.Run;
+
+        Assert.NotNull(run);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #35.

This PR fixes the file-based app path documented in the README and adds a committed sample for it under `samples/NXUI.Sample.FileApp`.

## What Changed

- Pack `src/NXUI.Desktop/NXUI.props` as `NXUI.Desktop.props` under both `build/` and `buildTransitive/` so NuGet imports the desktop package build assets using the package ID convention.
- Keep `ImplicitUsings.props` in the package next to the renamed desktop props file.
- Add regression tests that pin `NXUI.HotReload.HotReloadHost` as a public type in the expected namespace and verify the README-style file-app `Run` signature.
- Add `samples/NXUI.Sample.FileApp/App.cs`, matching the simple file-based app sample from the README, including the executable shebang.

## Root Cause

The published `NXUI.Desktop@11.3.0.1` package does not expose the README's `NXUI.HotReload.HotReloadHost` path. Current source already contains the host type for the upcoming `12.0.0` package, but the desktop package was still packing its build props as `NXUI.props`. NuGet expects build assets to use the package ID, so the desktop package emitted `NU5129` and would not auto-import those build assets by convention.

## Impact

Consumers using the documented .NET file-based app pattern can reference `NXUI.Desktop@12.0.0`, import `NXUI.HotReload`, and compile the sample app without adding an extra project file. The new sample also gives the README snippet a repository-backed smoke test target.

## Validation

- `dotnet test tests/NXUI.HotReload.Tests/NXUI.HotReload.Tests.csproj --logger "console;verbosity=minimal"`: 63 passed.
- `dotnet pack src/NXUI/NXUI.csproj -c Release -o /tmp/nxui-pr-pkgs`: passed.
- `dotnet pack src/NXUI.Desktop/NXUI.Desktop.csproj -c Release -o /tmp/nxui-pr-pkgs`: passed; the previous `NU5129` props warning is gone.
- Verified the packed `NXUI.Desktop.12.0.0.nupkg` contains `build/NXUI.Desktop.props` and `buildTransitive/NXUI.Desktop.props`.
- Ran `samples/NXUI.Sample.FileApp/App.cs` with a temporary local package source for `NXUI.Desktop@12.0.0`; the Avalonia app started and remained running until manually stopped.
