### PR TITLE
Add GitHub release workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,8 @@ jobs:
     - name: Test Release
       run: dotnet test -c Release --no-build
     - name: Pack Release
-      run: dotnet pack NXUI.sln -c Release --no-build -o artifacts/packages
+      shell: pwsh
+      run: ./build/PackPackages.ps1 -OutputPath artifacts/packages
     - name: Pack Release Symbols
       shell: pwsh
       run: ./build/PackSymbols.ps1 -OutputPath artifacts/packages

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,3 +30,22 @@ jobs:
       run: dotnet test -c Release --no-build
     - name: Pack Release
       run: dotnet pack NXUI.sln -c Release --no-build -o artifacts/packages
+    - name: Pack Release Symbols
+      shell: pwsh
+      run: |
+        $symbolProjects = @(
+          "src/NXUI/NXUI.csproj",
+          "src/NXUI.Desktop/NXUI.Desktop.csproj",
+          "src/NXUI.Cli/NXUI.Cli.csproj",
+          "src/NXUI.Fody/BoundaryWeaver/BoundaryWeaver.csproj",
+          "src/Reflectonia/Reflectonia.csproj"
+        )
+
+        foreach ($project in $symbolProjects) {
+          dotnet pack $project `
+            -c Release `
+            --no-build `
+            -o artifacts/packages `
+            -p:IncludeSymbols=true `
+            -p:SymbolPackageFormat=snupkg
+        }

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,20 +32,4 @@ jobs:
       run: dotnet pack NXUI.sln -c Release --no-build -o artifacts/packages
     - name: Pack Release Symbols
       shell: pwsh
-      run: |
-        $symbolProjects = @(
-          "src/NXUI/NXUI.csproj",
-          "src/NXUI.Desktop/NXUI.Desktop.csproj",
-          "src/NXUI.Cli/NXUI.Cli.csproj",
-          "src/NXUI.Fody/BoundaryWeaver/BoundaryWeaver.csproj",
-          "src/Reflectonia/Reflectonia.csproj"
-        )
-
-        foreach ($project in $symbolProjects) {
-          dotnet pack $project `
-            -c Release `
-            --no-build `
-            -o artifacts/packages `
-            -p:IncludeSymbols=true `
-            -p:SymbolPackageFormat=snupkg
-        }
+      run: ./build/PackSymbols.ps1 -OutputPath artifacts/packages

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -155,8 +155,30 @@ jobs:
       - name: Build
         run: dotnet build NXUI.sln -c Release --no-restore -p:Version=${{ needs.build.outputs.version }} -p:ContinuousIntegrationBuild=true
 
-      - name: Pack
+      - name: Pack NuGet packages
         run: dotnet pack NXUI.sln -c Release --no-build -o artifacts/packages -p:Version=${{ needs.build.outputs.version }} -p:ContinuousIntegrationBuild=true
+
+      - name: Pack symbol packages
+        shell: bash
+        run: |
+          symbol_projects=(
+            src/NXUI/NXUI.csproj
+            src/NXUI.Desktop/NXUI.Desktop.csproj
+            src/NXUI.Cli/NXUI.Cli.csproj
+            src/NXUI.Fody/BoundaryWeaver/BoundaryWeaver.csproj
+            src/Reflectonia/Reflectonia.csproj
+          )
+
+          for project in "${symbol_projects[@]}"; do
+            dotnet pack "$project" \
+              -c Release \
+              --no-build \
+              -o artifacts/packages \
+              -p:Version=${{ needs.build.outputs.version }} \
+              -p:ContinuousIntegrationBuild=true \
+              -p:IncludeSymbols=true \
+              -p:SymbolPackageFormat=snupkg
+          done
 
       - name: Upload NuGet packages
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,236 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to release (e.g., 12.0.0)'
+        required: true
+        type: string
+      prerelease:
+        description: 'Is this a pre-release?'
+        required: false
+        type: boolean
+        default: false
+
+env:
+  DOTNET_NOLOGO: true
+  DOTNET_CLI_TELEMETRY_OPTOUT: true
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build Release
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      tag_name: ${{ steps.version.outputs.tag_name }}
+      is_prerelease: ${{ steps.version.outputs.is_prerelease }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          global-json-file: global.json
+
+      - name: Install wasm tools
+        run: dotnet workload install wasm-tools wasm-experimental
+
+      - name: Determine version
+        id: version
+        shell: bash
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            VERSION="${{ github.event.inputs.version }}"
+            REQUESTED_PRERELEASE="${{ github.event.inputs.prerelease }}"
+            VERSION="${VERSION#v}"
+            TAG_NAME="v${VERSION}"
+          else
+            TAG_NAME="${GITHUB_REF_NAME}"
+            VERSION="${TAG_NAME#v}"
+            REQUESTED_PRERELEASE="false"
+          fi
+
+          if [[ ! "$VERSION" =~ ^[0-9]+(\.[0-9]+){1,3}(-[0-9A-Za-z][0-9A-Za-z.-]*)?$ ]]; then
+            echo "Invalid release version '$VERSION'. Use a NuGet-compatible version such as 12.0.0 or 12.0.0-preview.1." >&2
+            exit 1
+          fi
+
+          if [[ "$VERSION" == *"-"* || "$REQUESTED_PRERELEASE" == "true" ]]; then
+            IS_PRERELEASE="true"
+          else
+            IS_PRERELEASE="false"
+          fi
+
+          {
+            echo "version=$VERSION"
+            echo "tag_name=$TAG_NAME"
+            echo "is_prerelease=$IS_PRERELEASE"
+          } >> "$GITHUB_OUTPUT"
+          echo "Building NXUI $VERSION (tag: $TAG_NAME, prerelease: $IS_PRERELEASE)"
+
+      - name: Restore
+        run: dotnet restore NXUI.sln
+
+      - name: Build
+        run: dotnet build NXUI.sln -c Release --no-restore -p:Version=${{ steps.version.outputs.version }} -p:ContinuousIntegrationBuild=true
+
+  test:
+    name: Test Release
+    runs-on: ubuntu-latest
+    needs: build
+    permissions:
+      contents: read
+      checks: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          global-json-file: global.json
+
+      - name: Install wasm tools
+        run: dotnet workload install wasm-tools wasm-experimental
+
+      - name: Restore
+        run: dotnet restore NXUI.sln
+
+      - name: Build
+        run: dotnet build NXUI.sln -c Release --no-restore -p:Version=${{ needs.build.outputs.version }} -p:ContinuousIntegrationBuild=true
+
+      - name: Test
+        run: dotnet test NXUI.sln -c Release --no-build --logger trx --results-directory artifacts/test -p:Version=${{ needs.build.outputs.version }} -p:ContinuousIntegrationBuild=true
+
+      - name: Upload test results
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: release-test-results
+          path: artifacts/test/**/*.trx
+          if-no-files-found: error
+          retention-days: 7
+
+      - name: Publish test results
+        uses: dorny/test-reporter@v1
+        if: always()
+        with:
+          name: Release Test Results
+          path: artifacts/test/**/*.trx
+          reporter: dotnet-trx
+          fail-on-empty: false
+
+  pack:
+    name: Pack Release
+    runs-on: ubuntu-latest
+    needs: [build, test]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          global-json-file: global.json
+
+      - name: Install wasm tools
+        run: dotnet workload install wasm-tools wasm-experimental
+
+      - name: Restore
+        run: dotnet restore NXUI.sln
+
+      - name: Build
+        run: dotnet build NXUI.sln -c Release --no-restore -p:Version=${{ needs.build.outputs.version }} -p:ContinuousIntegrationBuild=true
+
+      - name: Pack
+        run: dotnet pack NXUI.sln -c Release --no-build -o artifacts/packages -p:Version=${{ needs.build.outputs.version }} -p:ContinuousIntegrationBuild=true
+
+      - name: Upload NuGet packages
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-nuget-packages
+          path: |
+            artifacts/packages/*.nupkg
+            artifacts/packages/*.snupkg
+          if-no-files-found: error
+          retention-days: 90
+
+  publish-nuget:
+    name: Publish to NuGet
+    runs-on: ubuntu-latest
+    needs: [build, pack]
+    environment: nuget
+    steps:
+      - name: Download NuGet packages
+        uses: actions/download-artifact@v4
+        with:
+          name: release-nuget-packages
+          path: packages
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Publish to NuGet
+        shell: bash
+        run: |
+          shopt -s nullglob
+          packages=(packages/*.nupkg packages/*.snupkg)
+
+          if (( ${#packages[@]} == 0 )); then
+            echo "No NuGet packages found to publish." >&2
+            exit 1
+          fi
+
+          for package in "${packages[@]}"; do
+            echo "Publishing $package..."
+            dotnet nuget push "$package" \
+              --api-key "${{ secrets.NUGET_API_KEY }}" \
+              --source https://api.nuget.org/v3/index.json \
+              --skip-duplicate
+          done
+
+  create-release:
+    name: Create GitHub Release
+    runs-on: ubuntu-latest
+    needs: [build, pack, publish-nuget]
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download NuGet packages
+        uses: actions/download-artifact@v4
+        with:
+          name: release-nuget-packages
+          path: packages
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          name: NXUI v${{ needs.build.outputs.version }}
+          tag_name: ${{ needs.build.outputs.tag_name }}
+          target_commitish: ${{ github.sha }}
+          draft: false
+          prerelease: ${{ needs.build.outputs.is_prerelease == 'true' }}
+          generate_release_notes: true
+          files: |
+            packages/*.nupkg
+            packages/*.snupkg
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -156,7 +156,8 @@ jobs:
         run: dotnet build NXUI.sln -c Release --no-restore -p:Version=${{ needs.build.outputs.version }} -p:ContinuousIntegrationBuild=true
 
       - name: Pack NuGet packages
-        run: dotnet pack NXUI.sln -c Release --no-build -o artifacts/packages -p:Version=${{ needs.build.outputs.version }} -p:ContinuousIntegrationBuild=true
+        shell: pwsh
+        run: ./build/PackPackages.ps1 -OutputPath artifacts/packages -Version '${{ needs.build.outputs.version }}' -ContinuousIntegrationBuild
 
       - name: Pack symbol packages
         shell: pwsh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -159,26 +159,8 @@ jobs:
         run: dotnet pack NXUI.sln -c Release --no-build -o artifacts/packages -p:Version=${{ needs.build.outputs.version }} -p:ContinuousIntegrationBuild=true
 
       - name: Pack symbol packages
-        shell: bash
-        run: |
-          symbol_projects=(
-            src/NXUI/NXUI.csproj
-            src/NXUI.Desktop/NXUI.Desktop.csproj
-            src/NXUI.Cli/NXUI.Cli.csproj
-            src/NXUI.Fody/BoundaryWeaver/BoundaryWeaver.csproj
-            src/Reflectonia/Reflectonia.csproj
-          )
-
-          for project in "${symbol_projects[@]}"; do
-            dotnet pack "$project" \
-              -c Release \
-              --no-build \
-              -o artifacts/packages \
-              -p:Version=${{ needs.build.outputs.version }} \
-              -p:ContinuousIntegrationBuild=true \
-              -p:IncludeSymbols=true \
-              -p:SymbolPackageFormat=snupkg
-          done
+        shell: pwsh
+        run: ./build/PackSymbols.ps1 -OutputPath artifacts/packages -Version '${{ needs.build.outputs.version }}' -ContinuousIntegrationBuild
 
       - name: Upload NuGet packages
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,6 +66,11 @@ jobs:
             exit 1
           fi
 
+          if [[ "$REQUESTED_PRERELEASE" == "true" && "$VERSION" != *"-"* ]]; then
+            echo "Manual prerelease runs must use a NuGet prerelease version such as 12.0.0-preview.1." >&2
+            exit 1
+          fi
+
           if [[ "$VERSION" == *"-"* || "$REQUESTED_PRERELEASE" == "true" ]]; then
             IS_PRERELEASE="true"
           else

--- a/build/PackPackages.ps1
+++ b/build/PackPackages.ps1
@@ -1,0 +1,44 @@
+[CmdletBinding()]
+param(
+    [string] $Configuration = "Release",
+    [string] $OutputPath = "artifacts/packages",
+    [string] $Version = "",
+    [switch] $ContinuousIntegrationBuild
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$repoRoot = Split-Path -Parent $PSScriptRoot
+$solutionPath = Join-Path $repoRoot "NXUI.sln"
+$resolvedOutputPath = if ([System.IO.Path]::IsPathRooted($OutputPath)) {
+    $OutputPath
+} else {
+    Join-Path $repoRoot $OutputPath
+}
+
+New-Item -ItemType Directory -Force -Path $resolvedOutputPath | Out-Null
+
+$packArgs = @(
+    "pack",
+    $solutionPath,
+    "-c",
+    $Configuration,
+    "--no-build",
+    "-o",
+    $resolvedOutputPath
+)
+
+if ($Version) {
+    $packArgs += "-p:Version=$Version"
+}
+
+if ($ContinuousIntegrationBuild) {
+    $packArgs += "-p:ContinuousIntegrationBuild=true"
+}
+
+Write-Host "Packing NuGet packages from $solutionPath"
+& dotnet @packArgs
+if ($LASTEXITCODE -ne 0) {
+    throw "dotnet pack failed for $solutionPath with exit code $LASTEXITCODE."
+}

--- a/build/PackSymbols.ps1
+++ b/build/PackSymbols.ps1
@@ -1,0 +1,56 @@
+[CmdletBinding()]
+param(
+    [string] $Configuration = "Release",
+    [string] $OutputPath = "artifacts/packages",
+    [string] $Version = "",
+    [switch] $ContinuousIntegrationBuild
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$repoRoot = Split-Path -Parent $PSScriptRoot
+$resolvedOutputPath = if ([System.IO.Path]::IsPathRooted($OutputPath)) {
+    $OutputPath
+} else {
+    Join-Path $repoRoot $OutputPath
+}
+
+New-Item -ItemType Directory -Force -Path $resolvedOutputPath | Out-Null
+
+$symbolProjects = @(
+    "src/NXUI/NXUI.csproj",
+    "src/NXUI.Desktop/NXUI.Desktop.csproj",
+    "src/NXUI.Cli/NXUI.Cli.csproj",
+    "src/NXUI.Fody/BoundaryWeaver/BoundaryWeaver.csproj",
+    "src/Reflectonia/Reflectonia.csproj"
+)
+
+foreach ($project in $symbolProjects) {
+    $projectPath = Join-Path $repoRoot $project
+    $packArgs = @(
+        "pack",
+        $projectPath,
+        "-c",
+        $Configuration,
+        "--no-build",
+        "-o",
+        $resolvedOutputPath,
+        "-p:IncludeSymbols=true",
+        "-p:SymbolPackageFormat=snupkg"
+    )
+
+    if ($Version) {
+        $packArgs += "-p:Version=$Version"
+    }
+
+    if ($ContinuousIntegrationBuild) {
+        $packArgs += "-p:ContinuousIntegrationBuild=true"
+    }
+
+    Write-Host "Packing symbols for $project"
+    & dotnet @packArgs
+    if ($LASTEXITCODE -ne 0) {
+        throw "dotnet pack failed for $project with exit code $LASTEXITCODE."
+    }
+}

--- a/build/PackSymbols.ps1
+++ b/build/PackSymbols.ps1
@@ -26,8 +26,14 @@ $symbolProjects = @(
     "src/Reflectonia/Reflectonia.csproj"
 )
 
-foreach ($project in $symbolProjects) {
-    $projectPath = Join-Path $repoRoot $project
+function Invoke-SymbolPack {
+    param(
+        [string] $Project,
+        [string] $PackOutputPath,
+        [string[]] $ExtraProperties = @()
+    )
+
+    $projectPath = Join-Path $repoRoot $Project
     $packArgs = @(
         "pack",
         $projectPath,
@@ -35,10 +41,12 @@ foreach ($project in $symbolProjects) {
         $Configuration,
         "--no-build",
         "-o",
-        $resolvedOutputPath,
+        $PackOutputPath,
         "-p:IncludeSymbols=true",
         "-p:SymbolPackageFormat=snupkg"
     )
+
+    $packArgs += $ExtraProperties
 
     if ($Version) {
         $packArgs += "-p:Version=$Version"
@@ -48,9 +56,47 @@ foreach ($project in $symbolProjects) {
         $packArgs += "-p:ContinuousIntegrationBuild=true"
     }
 
-    Write-Host "Packing symbols for $project"
+    Write-Host "Packing symbols for $Project"
     & dotnet @packArgs
     if ($LASTEXITCODE -ne 0) {
-        throw "dotnet pack failed for $project with exit code $LASTEXITCODE."
+        throw "dotnet pack failed for $Project with exit code $LASTEXITCODE."
+    }
+}
+
+foreach ($project in $symbolProjects) {
+    Invoke-SymbolPack -Project $project -PackOutputPath $resolvedOutputPath
+}
+
+$analyzerSymbolProjects = @(
+    "src/NXUI.Analyzers/NXUI.Analyzers.csproj"
+)
+
+$analyzerOutputPath = Join-Path ([System.IO.Path]::GetTempPath()) "nxui-analyzer-symbols-$([System.Guid]::NewGuid().ToString('N'))"
+
+try {
+    New-Item -ItemType Directory -Force -Path $analyzerOutputPath | Out-Null
+
+    # Analyzer packages suppress regular build output, so produce their snupkg in
+    # isolation and copy only the symbol package back to the release artifacts.
+    foreach ($project in $analyzerSymbolProjects) {
+        Invoke-SymbolPack `
+            -Project $project `
+            -PackOutputPath $analyzerOutputPath `
+            -ExtraProperties @(
+                "-p:IncludeBuildOutput=true",
+                "-p:BuildOutputTargetFolder=analyzers/dotnet/cs"
+            )
+    }
+
+    $analyzerSymbolPackages = @(Get-ChildItem -Path $analyzerOutputPath -Filter "*.snupkg")
+    if ($analyzerSymbolPackages.Count -eq 0) {
+        throw "No analyzer symbol packages were produced."
+    }
+
+    $analyzerSymbolPackages | Copy-Item -Destination $resolvedOutputPath -Force
+}
+finally {
+    if (Test-Path $analyzerOutputPath) {
+        Remove-Item -Recurse -Force $analyzerOutputPath
     }
 }


### PR DESCRIPTION
## Summary

This PR adds a GitHub Actions release workflow for NXUI based on the existing PanAndZoom release workflow, adapted to this repository's solution layout, package metadata, and CI requirements.

The new workflow runs on `v*` tags and supports manual dispatch with an explicit release version and prerelease flag. It resolves the release version once, passes that version into all build, test, and pack commands, publishes the generated NuGet packages, and creates a GitHub Release with the packaged artifacts attached.

## What Changed

- Added `.github/workflows/release.yml`.
- Added release triggers for pushed `v*` tags and manual `workflow_dispatch` runs.
- Added version resolution for both tag-driven and manually triggered releases.
- Added NuGet-compatible version validation before build and packaging.
- Added prerelease detection from either a SemVer prerelease suffix or the manual prerelease flag.
- Used `global.json` for .NET SDK setup so release uses the same SDK policy as the repository.
- Installed `wasm-tools` and `wasm-experimental`, matching the existing CI workflow prerequisites.
- Built, tested, and packed `NXUI.sln` in Release configuration.
- Passed `-p:Version=<release version>` and `-p:ContinuousIntegrationBuild=true` through build, test, and pack steps so package versions and project-to-project package dependencies are consistent with the release tag.
- Uploaded test results and NuGet packages as workflow artifacts.
- Published `.nupkg` and `.snupkg` files to NuGet using `secrets.NUGET_API_KEY`.
- Created a GitHub Release named `NXUI v<version>` using `softprops/action-gh-release@v2`.
- Attached generated NuGet package artifacts to the GitHub Release.
- Set default workflow permissions to read-only and granted `contents: write` only to the GitHub Release creation job.

## Why

NXUI already had CI coverage for restore, build, test, and pack, but did not have a release workflow to publish packages or create GitHub Releases. This adds an end-to-end release path while preserving the repository's existing CI behavior and package conventions.

The repository centralizes package metadata in `Directory.Build.props`, currently including a static `VersionPrefix`. The release workflow overrides `Version` at build and pack time so released packages match the pushed tag or manual release input instead of relying on the static project metadata version.

## Package Impact

The workflow packages the existing packable projects in `NXUI.sln`:

- `NXUI`
- `NXUI.Desktop`
- `NXUI.Cli`
- `NXUI.Analyzers`
- `NXUI.Fody`
- `Reflectonia`

Samples and test projects remain excluded because they are marked with `IsPackable=false`.

## Validation

Validated locally with:

```sh
actionlint .github/workflows/release.yml
dotnet restore NXUI.sln
dotnet build NXUI.sln -c Release --no-restore -p:Version=12.0.0-ci -p:ContinuousIntegrationBuild=true
dotnet test NXUI.sln -c Release --no-build --logger trx --results-directory /tmp/nxui-release-test -p:Version=12.0.0-ci -p:ContinuousIntegrationBuild=true
dotnet pack NXUI.sln -c Release --no-build -o /tmp/nxui-release-packages -p:Version=12.0.0-ci -p:ContinuousIntegrationBuild=true
```

The local pack check produced the expected six NuGet packages using the overridden version. The generated `NXUI.Desktop` package metadata also used the overridden release version for its dependency on `NXUI`.

## Operational Notes

To publish a release, push a tag like `v12.0.0` or run the workflow manually with `version` set to a NuGet-compatible version such as `12.0.0` or `12.0.0-preview.1`.

The NuGet publish job requires `NUGET_API_KEY` to be configured in repository or environment secrets and uses the `nuget` GitHub environment.
